### PR TITLE
Add support for Iterable as interface parameter type

### DIFF
--- a/fluapigen-integrationTest/src/main/java/io/toolisticon/fluapigen/integrationtest/IntegrationTest.java
+++ b/fluapigen-integrationTest/src/main/java/io/toolisticon/fluapigen/integrationtest/IntegrationTest.java
@@ -6,7 +6,6 @@ import io.toolisticon.fluapigen.api.FluentApiBackingBeanField;
 import io.toolisticon.fluapigen.api.FluentApiBackingBeanMapping;
 import io.toolisticon.fluapigen.api.FluentApiCommand;
 import io.toolisticon.fluapigen.api.FluentApiImplicitValue;
-import io.toolisticon.fluapigen.api.FluentApiInlineBackingBeanMapping;
 import io.toolisticon.fluapigen.api.FluentApiInterface;
 import io.toolisticon.fluapigen.api.FluentApiParentBackingBeanMapping;
 import io.toolisticon.fluapigen.api.FluentApiRoot;
@@ -28,7 +27,6 @@ public class IntegrationTest {
 
         @FluentApiBackingBeanField("midLevelBB")
         List<MyMidLevelBackingBean> midLevelBB();
-
 
 
     }
@@ -143,21 +141,34 @@ public class IntegrationTest {
         @FluentApiParentBackingBeanMapping(value = "midLevelBB")
         MyRootInterface gotoParent();
 
-        MyMidLevelInterface setStringArray(@FluentApiBackingBeanMapping(value = "stringArray") String ... strings);
+        MyMidLevelInterface setStringArray(@FluentApiBackingBeanMapping(value = "stringArray") String... strings);
 
-        @FluentApiImplicitValue(id = "stringArray", value = {"XYZ","123"})
+        @FluentApiImplicitValue(id = "stringArray", value = {"XYZ", "123"})
         MyMidLevelInterface setStringArrayImplicitly();
 
 
-        MyMidLevelInterface setStringList(@FluentApiBackingBeanMapping(value = "stringList") String ... strings);
+        MyMidLevelInterface setStringList(@FluentApiBackingBeanMapping(value = "stringList") String... strings);
 
         MyMidLevelInterface addStringListValue(@FluentApiBackingBeanMapping(value = "stringList", action = MappingAction.ADD) String singleString);
 
-        MyMidLevelInterface addStringListValues(@FluentApiBackingBeanMapping(value = "stringList", action = MappingAction.ADD) String ... singleString);
+        MyMidLevelInterface addStringListValues(@FluentApiBackingBeanMapping(value = "stringList", action = MappingAction.ADD) String... singleString);
 
+        MyMidLevelInterface addStringListValues(@FluentApiBackingBeanMapping(value = "stringList", action = MappingAction.ADD) Iterable<String> iterable);
 
-        @FluentApiImplicitValue(id = "stringList", value = {"XYZ","123"})
+        @FluentApiImplicitValue(id = "stringList", value = {"XYZ", "123"})
         MyMidLevelInterface setStringListImplicitly();
+
+        MyMidLevelInterface setStringSet(@FluentApiBackingBeanMapping(value = "stringSet") String... strings);
+
+        MyMidLevelInterface addStringSetValue(@FluentApiBackingBeanMapping(value = "stringSet", action = MappingAction.ADD) String singleString);
+
+        MyMidLevelInterface addStringSetValues(@FluentApiBackingBeanMapping(value = "stringSet", action = MappingAction.ADD) String... singleString);
+
+        MyMidLevelInterface addStringSetValues(@FluentApiBackingBeanMapping(value = "stringSet", action = MappingAction.ADD) Iterable<String> iterable);
+
+
+        @FluentApiImplicitValue(id = "stringSet", value = {"XYZ", "123"})
+        MyMidLevelInterface setStringSetImplicitly();
 
     }
 

--- a/fluapigen-integrationTest/src/main/java/io/toolisticon/fluapigen/integrationtest/ValidatorExample.java
+++ b/fluapigen-integrationTest/src/main/java/io/toolisticon/fluapigen/integrationtest/ValidatorExample.java
@@ -7,10 +7,14 @@ import io.toolisticon.fluapigen.api.FluentApiBackingBeanMapping;
 import io.toolisticon.fluapigen.api.FluentApiCommand;
 import io.toolisticon.fluapigen.api.FluentApiInterface;
 import io.toolisticon.fluapigen.api.FluentApiRoot;
+import io.toolisticon.fluapigen.api.MappingAction;
+import io.toolisticon.fluapigen.validation.api.HasNoArgConstructor;
 import io.toolisticon.fluapigen.validation.api.Matches;
 import io.toolisticon.fluapigen.validation.api.MaxLength;
 import io.toolisticon.fluapigen.validation.api.NotNull;
 import io.toolisticon.fluapigen.validation.api.Nullable;
+
+import java.util.List;
 
 @FluentApi("ValidatorExampleStarter")
 public class ValidatorExample {
@@ -21,6 +25,12 @@ public class ValidatorExample {
 
         @FluentApiBackingBeanField("name")
         String getName();
+
+        @FluentApiBackingBeanField("variousNames")
+        List<String> getVariousNames();
+
+        @FluentApiBackingBeanField("classes")
+        List<Class<?>> getClasses();
 
     }
 
@@ -38,6 +48,17 @@ public class ValidatorExample {
         @Nullable
         MyRootInterface setNameWithNullableOnMethod(@NotNull @MaxLength(8) @Matches("aaa.*") @FluentApiBackingBeanMapping("name") String name);
 
+        @Nullable
+        MyRootInterface setVariousNamesWithNullableOnMethod(@NotNull @MaxLength(8) @Matches("aaa.*") @FluentApiBackingBeanMapping("variousNames") String... names);
+
+        @Nullable
+        MyRootInterface setVariousNamesWithNullableOnMethod(@NotNull @MaxLength(8) @Matches("aaa.*") @FluentApiBackingBeanMapping("variousNames") List<String> names);
+
+        MyRootInterface addClass(@NotNull @HasNoArgConstructor @FluentApiBackingBeanMapping(value = "classes", action = MappingAction.ADD) Class<?> clazz);
+
+        MyRootInterface addClasses(@NotNull @HasNoArgConstructor @FluentApiBackingBeanMapping(value = "classes", action = MappingAction.ADD) Class<?>... clazz);
+
+        MyRootInterface addClasses(@NotNull @HasNoArgConstructor @FluentApiBackingBeanMapping(value = "classes", action = MappingAction.ADD) Iterable<Class<?>> clazz);
 
         @FluentApiCommand(MyCommand.class)
         void myCommand();
@@ -49,6 +70,7 @@ public class ValidatorExample {
     static class MyCommand {
         static void myCommand(MyBackingBean backingBean) {
             System.out.println(backingBean.getName());
+            System.out.println(backingBean.getVariousNames());
         }
     }
 

--- a/fluapigen-integrationTest/src/test/java/io/toolisticon/fluapigen/integrationtest/IntegrationTestTest.java
+++ b/fluapigen-integrationTest/src/test/java/io/toolisticon/fluapigen/integrationtest/IntegrationTestTest.java
@@ -4,6 +4,8 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 public class IntegrationTestTest {
 
     @Test
@@ -249,14 +251,14 @@ public class IntegrationTestTest {
                 .setName("NAME")
                 .gotoMidLevel()
                 .setStringArray("XXX")
-                .setStringArray("ABC", "DEF","GHI")
+                .setStringArray("ABC", "DEF", "GHI")
                 .gotoParent()
                 .myCommand();
 
         MatcherAssert.assertThat(backingBean.getName(), Matchers.is("NAME"));
         MatcherAssert.assertThat(backingBean.midLevelBB(), Matchers.notNullValue());
         MatcherAssert.assertThat(backingBean.midLevelBB(), Matchers.hasSize(1));
-        MatcherAssert.assertThat(backingBean.midLevelBB().get(0).stringArray(), Matchers.arrayContaining("ABC", "DEF","GHI"));
+        MatcherAssert.assertThat(backingBean.midLevelBB().get(0).stringArray(), Matchers.arrayContaining("ABC", "DEF", "GHI"));
 
 
     }
@@ -273,14 +275,14 @@ public class IntegrationTestTest {
         IntegrationTest.MyMidLevelInterface midLevel2 = midLevel1.setStringArrayImplicitly();
 
         MatcherAssert.assertThat(midLevel1.gotoParent().myCommand().midLevelBB().get(0).stringArray(), Matchers.arrayContaining("abc", "DEF"));
-        MatcherAssert.assertThat(midLevel2.gotoParent().myCommand().midLevelBB().get(0).stringArray(), Matchers.arrayContaining("XYZ","123"));
+        MatcherAssert.assertThat(midLevel2.gotoParent().myCommand().midLevelBB().get(0).stringArray(), Matchers.arrayContaining("XYZ", "123"));
 
 
-        IntegrationTest.MyMidLevelInterface midLevel3 = midLevel2.setStringArray("ABC", "DEF","GHI");
+        IntegrationTest.MyMidLevelInterface midLevel3 = midLevel2.setStringArray("ABC", "DEF", "GHI");
 
         MatcherAssert.assertThat(midLevel1.gotoParent().myCommand().midLevelBB().get(0).stringArray(), Matchers.arrayContaining("abc", "DEF"));
-        MatcherAssert.assertThat(midLevel2.gotoParent().myCommand().midLevelBB().get(0).stringArray(), Matchers.arrayContaining("XYZ","123"));
-        MatcherAssert.assertThat(midLevel3.gotoParent().myCommand().midLevelBB().get(0).stringArray(), Matchers.arrayContaining("ABC", "DEF","GHI"));
+        MatcherAssert.assertThat(midLevel2.gotoParent().myCommand().midLevelBB().get(0).stringArray(), Matchers.arrayContaining("XYZ", "123"));
+        MatcherAssert.assertThat(midLevel3.gotoParent().myCommand().midLevelBB().get(0).stringArray(), Matchers.arrayContaining("ABC", "DEF", "GHI"));
 
     }
 
@@ -291,14 +293,14 @@ public class IntegrationTestTest {
                 .setName("NAME")
                 .gotoMidLevel()
                 .setStringList("XXX")
-                .setStringList("ABC", "DEF","GHI")
+                .setStringList("ABC", "DEF", "GHI")
                 .gotoParent()
                 .myCommand();
 
         MatcherAssert.assertThat(backingBean.getName(), Matchers.is("NAME"));
         MatcherAssert.assertThat(backingBean.midLevelBB(), Matchers.notNullValue());
         MatcherAssert.assertThat(backingBean.midLevelBB(), Matchers.hasSize(1));
-        MatcherAssert.assertThat(backingBean.midLevelBB().get(0).stringList(), Matchers.contains("ABC", "DEF","GHI"));
+        MatcherAssert.assertThat(backingBean.midLevelBB().get(0).stringList(), Matchers.contains("ABC", "DEF", "GHI"));
 
 
     }
@@ -315,27 +317,98 @@ public class IntegrationTestTest {
         IntegrationTest.MyMidLevelInterface midLevel2 = midLevel1.setStringListImplicitly();
 
         MatcherAssert.assertThat(midLevel1.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.empty());
-        MatcherAssert.assertThat(midLevel2.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("XYZ","123"));
+        MatcherAssert.assertThat(midLevel2.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("XYZ", "123"));
 
-        IntegrationTest.MyMidLevelInterface midLevel3 = midLevel2.setStringList("ABC", "DEF","GHI");
+        IntegrationTest.MyMidLevelInterface midLevel3 = midLevel2.setStringList("ABC", "DEF", "GHI");
 
         MatcherAssert.assertThat(midLevel1.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.empty());
-        MatcherAssert.assertThat(midLevel2.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("XYZ","123"));
-        MatcherAssert.assertThat(midLevel3.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("ABC", "DEF","GHI"));
+        MatcherAssert.assertThat(midLevel2.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("XYZ", "123"));
+        MatcherAssert.assertThat(midLevel3.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("ABC", "DEF", "GHI"));
 
         IntegrationTest.MyMidLevelInterface midLevel4 = midLevel3.addStringListValue("JKL");
         MatcherAssert.assertThat(midLevel1.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.empty());
-        MatcherAssert.assertThat(midLevel2.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("XYZ","123"));
-        MatcherAssert.assertThat(midLevel3.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("ABC", "DEF","GHI"));
-        MatcherAssert.assertThat(midLevel4.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("ABC", "DEF","GHI", "JKL"));
+        MatcherAssert.assertThat(midLevel2.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("XYZ", "123"));
+        MatcherAssert.assertThat(midLevel3.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("ABC", "DEF", "GHI"));
+        MatcherAssert.assertThat(midLevel4.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("ABC", "DEF", "GHI", "JKL"));
 
         IntegrationTest.MyMidLevelInterface midLevel5 = midLevel4.addStringListValues("MNO", "PQR");
         MatcherAssert.assertThat(midLevel1.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.empty());
-        MatcherAssert.assertThat(midLevel2.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("XYZ","123"));
-        MatcherAssert.assertThat(midLevel3.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("ABC", "DEF","GHI"));
-        MatcherAssert.assertThat(midLevel4.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("ABC", "DEF","GHI", "JKL"));
-        MatcherAssert.assertThat(midLevel5.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("ABC", "DEF","GHI", "JKL","MNO", "PQR"));
+        MatcherAssert.assertThat(midLevel2.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("XYZ", "123"));
+        MatcherAssert.assertThat(midLevel3.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("ABC", "DEF", "GHI"));
+        MatcherAssert.assertThat(midLevel4.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("ABC", "DEF", "GHI", "JKL"));
+        MatcherAssert.assertThat(midLevel5.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("ABC", "DEF", "GHI", "JKL", "MNO", "PQR"));
 
+
+        IntegrationTest.MyMidLevelInterface midLevel6 = midLevel5.addStringListValues(Arrays.asList("ITER1", "ITER2"));
+        MatcherAssert.assertThat(midLevel1.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.empty());
+        MatcherAssert.assertThat(midLevel2.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("XYZ", "123"));
+        MatcherAssert.assertThat(midLevel3.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("ABC", "DEF", "GHI"));
+        MatcherAssert.assertThat(midLevel4.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("ABC", "DEF", "GHI", "JKL"));
+        MatcherAssert.assertThat(midLevel5.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("ABC", "DEF", "GHI", "JKL", "MNO", "PQR"));
+        MatcherAssert.assertThat(midLevel6.gotoParent().myCommand().midLevelBB().get(0).stringList(), Matchers.contains("ABC", "DEF", "GHI", "JKL", "MNO", "PQR","ITER1", "ITER2"));
+
+
+    }
+
+    @Test
+    public void test_fluentApi_gotoMidLevel_setStringSetViaVarargs() {
+
+        IntegrationTest.MyRootLevelBackingBean backingBean = IntegrationTestStarter
+                .setName("NAME")
+                .gotoMidLevel()
+                .setStringSet("XXX")
+                .setStringSet("ABC", "DEF", "GHI")
+                .gotoParent()
+                .myCommand();
+
+        MatcherAssert.assertThat(backingBean.getName(), Matchers.is("NAME"));
+        MatcherAssert.assertThat(backingBean.midLevelBB(), Matchers.notNullValue());
+        MatcherAssert.assertThat(backingBean.midLevelBB(), Matchers.hasSize(1));
+        MatcherAssert.assertThat(backingBean.midLevelBB().get(0).stringSet(), Matchers.contains("ABC", "DEF", "GHI"));
+
+
+    }
+
+    @Test
+    public void test_fluentApi_gotoMidLevel_setStringSetInDifferentWaysAndCheckImmutability() {
+
+        IntegrationTest.MyMidLevelInterface midLevel1 = IntegrationTestStarter
+                .setName("NAME")
+                .gotoMidLevel();
+
+        MatcherAssert.assertThat(midLevel1.gotoParent().myCommand().midLevelBB().get(0).stringSet(), Matchers.containsInAnyOrder("abc", "DEF"));
+
+        IntegrationTest.MyMidLevelInterface midLevel2 = midLevel1.setStringSetImplicitly();
+
+        MatcherAssert.assertThat(midLevel1.gotoParent().myCommand().midLevelBB().get(0).stringSet(), Matchers.containsInAnyOrder("abc", "DEF"));
+        MatcherAssert.assertThat(midLevel2.gotoParent().myCommand().midLevelBB().get(0).stringSet(), Matchers.containsInAnyOrder("XYZ", "123"));
+
+        IntegrationTest.MyMidLevelInterface midLevel3 = midLevel2.setStringSet("ABC", "DEF", "GHI");
+
+        MatcherAssert.assertThat(midLevel1.gotoParent().myCommand().midLevelBB().get(0).stringSet(), Matchers.containsInAnyOrder("abc", "DEF"));
+        MatcherAssert.assertThat(midLevel2.gotoParent().myCommand().midLevelBB().get(0).stringSet(), Matchers.containsInAnyOrder("XYZ", "123"));
+        MatcherAssert.assertThat(midLevel3.gotoParent().myCommand().midLevelBB().get(0).stringSet(), Matchers.containsInAnyOrder("ABC", "DEF", "GHI"));
+
+        IntegrationTest.MyMidLevelInterface midLevel4 = midLevel3.addStringSetValue("JKL");
+        MatcherAssert.assertThat(midLevel1.gotoParent().myCommand().midLevelBB().get(0).stringSet(), Matchers.containsInAnyOrder("abc", "DEF"));
+        MatcherAssert.assertThat(midLevel2.gotoParent().myCommand().midLevelBB().get(0).stringSet(), Matchers.containsInAnyOrder("XYZ", "123"));
+        MatcherAssert.assertThat(midLevel3.gotoParent().myCommand().midLevelBB().get(0).stringSet(), Matchers.containsInAnyOrder("ABC", "DEF", "GHI"));
+        MatcherAssert.assertThat(midLevel4.gotoParent().myCommand().midLevelBB().get(0).stringSet(), Matchers.containsInAnyOrder("ABC", "DEF", "GHI", "JKL"));
+
+        IntegrationTest.MyMidLevelInterface midLevel5 = midLevel4.addStringSetValues("MNO", "PQR");
+        MatcherAssert.assertThat(midLevel1.gotoParent().myCommand().midLevelBB().get(0).stringSet(), Matchers.containsInAnyOrder("abc", "DEF"));
+        MatcherAssert.assertThat(midLevel2.gotoParent().myCommand().midLevelBB().get(0).stringSet(), Matchers.containsInAnyOrder("XYZ", "123"));
+        MatcherAssert.assertThat(midLevel3.gotoParent().myCommand().midLevelBB().get(0).stringSet(), Matchers.containsInAnyOrder("ABC", "DEF", "GHI"));
+        MatcherAssert.assertThat(midLevel4.gotoParent().myCommand().midLevelBB().get(0).stringSet(), Matchers.containsInAnyOrder("ABC", "DEF", "GHI", "JKL"));
+        MatcherAssert.assertThat(midLevel5.gotoParent().myCommand().midLevelBB().get(0).stringSet(), Matchers.containsInAnyOrder("ABC", "DEF", "GHI", "JKL", "MNO", "PQR"));
+
+        IntegrationTest.MyMidLevelInterface midLevel6 = midLevel5.addStringSetValues(Arrays.asList("ITER1", "ITER2"));
+        MatcherAssert.assertThat(midLevel1.gotoParent().myCommand().midLevelBB().get(0).stringSet(), Matchers.containsInAnyOrder("abc", "DEF"));
+        MatcherAssert.assertThat(midLevel2.gotoParent().myCommand().midLevelBB().get(0).stringSet(), Matchers.containsInAnyOrder("XYZ", "123"));
+        MatcherAssert.assertThat(midLevel3.gotoParent().myCommand().midLevelBB().get(0).stringSet(), Matchers.containsInAnyOrder("ABC", "DEF", "GHI"));
+        MatcherAssert.assertThat(midLevel4.gotoParent().myCommand().midLevelBB().get(0).stringSet(), Matchers.containsInAnyOrder("ABC", "DEF", "GHI", "JKL"));
+        MatcherAssert.assertThat(midLevel5.gotoParent().myCommand().midLevelBB().get(0).stringSet(), Matchers.containsInAnyOrder("ABC", "DEF", "GHI", "JKL", "MNO", "PQR"));
+        MatcherAssert.assertThat(midLevel6.gotoParent().myCommand().midLevelBB().get(0).stringSet(), Matchers.containsInAnyOrder("ABC", "DEF", "GHI", "JKL", "MNO", "PQR", "ITER1", "ITER2"));
 
 
     }
@@ -355,8 +428,8 @@ public class IntegrationTestTest {
 
     @Test
     public void testInheritance() {
-       IntegrationTest_Inheritance_reusingInterfaces.MyRootLevelBackingBean bb = InheritanceIntegrationTestStarter.goto1st().setName("1stName").set1st("1").goto2nd().setName("2ndName").set1st("2").myCommand();
-       MatcherAssert.assertThat(bb, Matchers.notNullValue());
+        IntegrationTest_Inheritance_reusingInterfaces.MyRootLevelBackingBean bb = InheritanceIntegrationTestStarter.goto1st().setName("1stName").set1st("1").goto2nd().setName("2ndName").set1st("2").myCommand();
+        MatcherAssert.assertThat(bb, Matchers.notNullValue());
     }
 
 }

--- a/fluapigen-integrationTest/src/test/java/io/toolisticon/fluapigen/integrationtest/ValidatorExampleTest.java
+++ b/fluapigen-integrationTest/src/test/java/io/toolisticon/fluapigen/integrationtest/ValidatorExampleTest.java
@@ -3,6 +3,9 @@ package io.toolisticon.fluapigen.integrationtest;
 import io.toolisticon.fluapigen.validation.api.ValidatorException;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class ValidatorExampleTest {
 
     @Test(expected = RuntimeException.class)
@@ -18,12 +21,49 @@ public class ValidatorExampleTest {
         ValidatorExampleStarter.setName("aaaBDSXS").myCommand();
         ValidatorExampleStarter.setNameWithNullableOnParameter(null).myCommand();
         ValidatorExampleStarter.setNameWithNullableOnMethod("aaaBDSXS").myCommand();
-
+        ValidatorExampleStarter.setVariousNamesWithNullableOnMethod("aaaBDSXS", "aaaBDNNN").myCommand();
+        ValidatorExampleStarter.setVariousNamesWithNullableOnMethod(Arrays.asList("aaaBDSXS", "aaaBDNNN")).myCommand();
+        ValidatorExampleStarter.addClass(ValidatorExampleTest.class).myCommand();
+        ValidatorExampleStarter.addClasses(ValidatorExampleTest.class).myCommand();
+        ValidatorExampleStarter.addClasses(Arrays.asList(ValidatorExampleTest.class)).myCommand();
     }
 
     @Test(expected = ValidatorException.class)
     public void testOverruledNotNullAtParameter() {
         ValidatorExampleStarter.setNameWithNullableOnMethod(null).myCommand();
+    }
+
+    @Test(expected = ValidatorException.class)
+    public void testOverruledNotNullAtParameter_List() {
+        ValidatorExampleStarter.setVariousNamesWithNullableOnMethod((List<String>)null).myCommand();
+    }
+
+    @Test(expected = ValidatorException.class)
+    public void testOverruledNotNullAtParameter_Array() {
+        ValidatorExampleStarter.setVariousNamesWithNullableOnMethod((String)null).myCommand();
+    }
+
+
+    static class NoNoargConstructor {
+        NoNoargConstructor (String arg) {
+
+        }
+    }
+
+    @Test(expected = ValidatorException.class)
+    public void testHasNoargConstructor_failing_singleValue() {
+        ValidatorExampleStarter.addClass(NoNoargConstructor.class).myCommand();
+    }
+
+
+    @Test(expected = ValidatorException.class)
+    public void testHasNoargConstructor_failing_arrayValue() {
+        ValidatorExampleStarter.addClasses(NoNoargConstructor.class).myCommand();
+    }
+
+    @Test(expected = ValidatorException.class)
+    public void testHasNoargConstructor_failing_iterableValue() {
+        ValidatorExampleStarter.addClasses(Arrays.asList(NoNoargConstructor.class)).myCommand();
     }
 
 }

--- a/fluapigen-processor/src/main/java/io/toolisticon/fluapigen/processor/ModelInterfaceMethodParameter.java
+++ b/fluapigen-processor/src/main/java/io/toolisticon/fluapigen/processor/ModelInterfaceMethodParameter.java
@@ -13,7 +13,6 @@ import io.toolisticon.fluapigen.validation.api.FluentApiValidator;
 
 import javax.lang.model.element.Element;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/fluapigen-processor/src/main/java/io/toolisticon/fluapigen/processor/ModelInterfaceMethodParameter.java
+++ b/fluapigen-processor/src/main/java/io/toolisticon/fluapigen/processor/ModelInterfaceMethodParameter.java
@@ -13,6 +13,7 @@ import io.toolisticon.fluapigen.validation.api.FluentApiValidator;
 
 import javax.lang.model.element.Element;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -164,7 +165,7 @@ public class ModelInterfaceMethodParameter {
                         } else if (type.isCollection()) {
                             return " = new " + backBeanField.get().getCollectionImplType() + "(" + addConverterIfNeeded(getParameterName()) + ");";
                         } else if(type.isIterable()){
-                            return " = " + generateSourceForIterableToList(addConverterIfNeeded(getParameterName())) + ";";
+                            return " = new " + backBeanField.get().getCollectionImplType() + "(" + generateSourceForIterableToList(addConverterIfNeeded(getParameterName())) + ");";
                         } else {
                             return " = new " + backBeanField.get().getCollectionImplType() + "(Collections.singletonList( " + addConverterIfNeeded(getParameterName()) + " ));";
                         }

--- a/fluapigen-processor/src/main/java/io/toolisticon/fluapigen/processor/ModelInterfaceMethodParameter.java
+++ b/fluapigen-processor/src/main/java/io/toolisticon/fluapigen/processor/ModelInterfaceMethodParameter.java
@@ -225,7 +225,7 @@ public class ModelInterfaceMethodParameter {
     }
 
     private String generateSourceForIterableToList(String parameterName){
-        return "StreamSupport.stream(((Iterable<Class<? extends Processor>>)" + parameterName + ").spliterator(), false).collect(Collectors.toList())";
+        return "StreamSupport.stream((" + parameterName + ").spliterator(), false).collect(Collectors.toList())";
     }
 
     private void validateConverter(ModelBackingBeanField backBeanField) {

--- a/fluapigen-processor/src/main/java/io/toolisticon/fluapigen/processor/ModelValidator.java
+++ b/fluapigen-processor/src/main/java/io/toolisticon/fluapigen/processor/ModelValidator.java
@@ -112,7 +112,20 @@ public class ModelValidator {
 
     public String validatorExpression() {
         StringBuilder stringBuilder = new StringBuilder();
-        stringBuilder.append("new ").append(getValidatorAnnotation().valueAsFqn()).append("(");
+
+        String genericTypeString = "";
+        // Need to handle generic validator separately
+        if (getValidatorAnnotation().valueAsTypeMirrorWrapper().getTypeElement().get().hasTypeParameters()) {
+            TypeMirrorWrapper annotatedElementsTypeMirror = annotatedElement.asType();
+            if (annotatedElementsTypeMirror.isCollection() || annotatedElementsTypeMirror.isIterable() || annotatedElementsTypeMirror.isArray()) {
+                genericTypeString = "<" +annotatedElementsTypeMirror.getWrappedComponentType().getTypeDeclaration() + ">";
+            } else {
+                genericTypeString = "<" + annotatedElementsTypeMirror.getTypeDeclaration() + ">";
+            }
+
+        }
+
+        stringBuilder.append("new ").append(getValidatorAnnotation().valueAsFqn()).append(genericTypeString).append("(");
 
         boolean isFirst = true;
         for (String attributeName : getValidatorAnnotation().attributeNamesToConstructorParameterMapping()) {

--- a/fluapigen-processor/src/test/java/io/toolisticon/fluapigen/processor/FluentApiProcessorTest.java
+++ b/fluapigen-processor/src/test/java/io/toolisticon/fluapigen/processor/FluentApiProcessorTest.java
@@ -206,7 +206,7 @@ public class FluentApiProcessorTest {
         compileTestBuilder
                 .andSourceFiles(JavaFileObjectUtils.readFromResource("testcases/IntegrationTest_NonUniqueBBFieldId.java"))
                 .whenCompiled().thenExpectThat().compilationFails()
-                .andThat().compilerMessage().ofKindError().contains(FluentApiProcessorCompilerMessages.ERROR_BACKING_BEAN_FIELD_ID_MUST_NOT_UNIQUE_IN_BB.getCode())
+                .andThat().compilerMessage().ofKindError().contains(FluentApiProcessorCompilerMessages.ERROR_BACKING_BEAN_FIELD_ID_MUST_BE_UNIQUE_IN_BB.getCode())
                 .executeTest();
 
     }
@@ -217,7 +217,7 @@ public class FluentApiProcessorTest {
         compileTestBuilder
                 .andSourceFiles(JavaFileObjectUtils.readFromResource("testcases/IntegrationTest_NonUniqueBBFieldId_ImplicitlySet.java"))
                 .whenCompiled().thenExpectThat().compilationFails()
-                .andThat().compilerMessage().ofKindError().contains(FluentApiProcessorCompilerMessages.ERROR_BACKING_BEAN_FIELD_ID_MUST_NOT_UNIQUE_IN_BB.getCode())
+                .andThat().compilerMessage().ofKindError().contains(FluentApiProcessorCompilerMessages.ERROR_BACKING_BEAN_FIELD_ID_MUST_BE_UNIQUE_IN_BB.getCode())
                 .executeTest();
 
     }

--- a/fluapigen-processor/src/test/java/io/toolisticon/fluapigen/processor/FluentApiProcessorTest.java
+++ b/fluapigen-processor/src/test/java/io/toolisticon/fluapigen/processor/FluentApiProcessorTest.java
@@ -82,7 +82,6 @@ public class FluentApiProcessorTest {
 
         compileTestBuilder
                 .andSourceFiles(JavaFileObjectUtils.readFromResource("testcases/IntegrationTest.java"))
-                //.whenCompiled().thenExpectThat().compilationFails()
                 .whenCompiled()
                 .thenExpectThat().compilationSucceeds()
                 .andThat().generatedSourceFile("io.toolisticon.fluapigen.testcases.IntegrationTestStarter").exists()

--- a/fluapigen-processor/src/test/java/io/toolisticon/fluapigen/processor/ValidatorTest.java
+++ b/fluapigen-processor/src/test/java/io/toolisticon/fluapigen/processor/ValidatorTest.java
@@ -123,7 +123,7 @@ public class ValidatorTest {
             }
 
             @Override
-            public boolean validate(String obj) {
+            public boolean validate(String object) {
                 return false;
             }
         }
@@ -213,7 +213,7 @@ public class ValidatorTest {
             }
 
             @Override
-            public boolean validate(String obj) {
+            public boolean validate(String object) {
 
                 return false;
             }
@@ -265,7 +265,7 @@ public class ValidatorTest {
             }
 
             @Override
-            public boolean validate(String obj) {
+            public boolean validate(String object) {
 
                 return false;
             }
@@ -319,7 +319,7 @@ public class ValidatorTest {
             }
 
             @Override
-            public boolean validate(String obj) {
+            public boolean validate(String object) {
 
                 return false;
             }

--- a/fluapigen-processor/src/test/resources/testcases/IntegrationTest.java
+++ b/fluapigen-processor/src/test/resources/testcases/IntegrationTest.java
@@ -12,6 +12,7 @@ import io.toolisticon.fluapigen.api.FluentApiRoot;
 import io.toolisticon.fluapigen.api.TargetBackingBean;
 
 import java.util.List;
+import java.util.Set;
 
 @FluentApi("IntegrationTestStarter")
 public class IntegrationTest {
@@ -38,7 +39,7 @@ public class IntegrationTest {
         List<String> stringList();
 
         @FluentApiBackingBeanField(value = "stringSet", initValue = {"abc", "DEF", "abc"})
-        List<String> stringSet();
+        Set<String> stringSet();
     }
 
     @FluentApiBackingBean

--- a/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/FluentApiValidator.java
+++ b/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/FluentApiValidator.java
@@ -16,7 +16,7 @@ public @interface FluentApiValidator {
      * The validator to be applied.
      * @return
      */
-    Class<? extends Validator<?>> value();
+    Class<? extends Validator> value();
 
     /**
      * Used to map parameters to validator constructor.

--- a/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/HasNoArgConstructor.java
+++ b/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/HasNoArgConstructor.java
@@ -27,7 +27,7 @@ public @interface HasNoArgConstructor {
         }
 
         @Override
-        public boolean validate(Class<?> obj) {
+        public boolean validate(Class<?> object) {
 
 
             if (object != null) {

--- a/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/HasNoArgConstructor.java
+++ b/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/HasNoArgConstructor.java
@@ -27,22 +27,22 @@ public @interface HasNoArgConstructor {
         }
 
         @Override
-        public boolean validate(Class obj) {
+        public boolean validate(Class object) {
 
-            if (obj != null) {
+            if (object != null) {
 
                 try {
 
                     // check if class is abstract
-                    if ((obj.getModifiers() & Modifier.ABSTRACT) != 0){
+                    if ((object.getModifiers() & Modifier.ABSTRACT) != 0){
                         return false;
                     }
 
                     // need to get constructor method
-                    Constructor<?> constructor = obj.getDeclaredConstructor();
+                    Constructor<?> constructor = object.getDeclaredConstructor();
 
                     for (int modifier : modifiers) {
-                        if ((modifier & obj.getModifiers()) == 0) {
+                        if ((modifier & object.getModifiers()) == 0) {
                             return false;
                         }
                     }
@@ -50,7 +50,7 @@ public @interface HasNoArgConstructor {
                 } catch (NoSuchMethodException e) {
 
                     // must check if there are any explicit constructors, if not then there is just the default public one.
-                    return obj.getDeclaredConstructors().length == 0 && hasPublicModifier();
+                    return object.getDeclaredConstructors().length == 0 && hasPublicModifier();
 
                 }
             }

--- a/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/Matches.java
+++ b/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/Matches.java
@@ -23,8 +23,8 @@ public @interface Matches {
         }
 
         @Override
-        public boolean validate(String obj) {
-            return obj == null || Pattern.compile(regularExpression).matcher(obj).matches();
+        public boolean validate(String object) {
+            return object == null || Pattern.compile(regularExpression).matcher(object).matches();
         }
 
     }

--- a/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/MaxLength.java
+++ b/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/MaxLength.java
@@ -27,8 +27,8 @@ public @interface MaxLength {
         }
 
         @Override
-        public boolean validate(String obj) {
-            return obj == null || obj.length() <= maxLength;
+        public boolean validate(String object) {
+            return object == null || object.length() <= maxLength;
         }
 
     }

--- a/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/MinLength.java
+++ b/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/MinLength.java
@@ -26,9 +26,9 @@ public @interface MinLength {
         }
 
         @Override
-        public boolean validate(String obj) {
+        public boolean validate(String object) {
 
-            return obj == null || obj.length() >= minLength;
+            return object == null || object.length() >= minLength;
 
         }
     }

--- a/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/NotEmpty.java
+++ b/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/NotEmpty.java
@@ -17,8 +17,8 @@ public @interface NotEmpty {
 
     class ValidatorImpl implements Validator<String> {
         @Override
-        public boolean validate(String obj) {
-            return obj == null || !obj.isEmpty();
+        public boolean validate(String object) {
+            return object == null || !object.isEmpty();
         }
     }
 

--- a/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/NotNull.java
+++ b/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/NotNull.java
@@ -4,6 +4,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.Collection;
 
 /**
  * Validates if values isn't null.
@@ -15,13 +16,18 @@ public @interface NotNull {
 
     class ValidatorImpl implements Validator<Object> {
         @Override
-        public boolean validate(Object obj) {
-            return obj != null;
+        public boolean validate(Object object) {
+            return object != null;
         }
 
         @Override
-        public boolean validate(Object[] obj) {
-            return obj != null && Validator.super.validate(obj);
+        public boolean validate(Object[] array) {
+            return array != null && Validator.super.validate(array);
+        }
+
+        @Override
+        public boolean validate(Iterable<Object> iterable){
+            return iterable != null && Validator.super.validate(iterable);
         }
     }
 

--- a/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/NotNull.java
+++ b/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/NotNull.java
@@ -4,7 +4,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.util.Collection;
 
 /**
  * Validates if values isn't null.
@@ -14,19 +13,19 @@ import java.util.Collection;
 @FluentApiValidator(value = NotNull.ValidatorImpl.class, overwrites = {Nullable.class})
 public @interface NotNull {
 
-    class ValidatorImpl implements Validator<Object> {
+    class ValidatorImpl<T> implements Validator<T> {
         @Override
-        public boolean validate(Object object) {
+        public boolean validate(T object) {
             return object != null;
         }
 
         @Override
-        public boolean validate(Object[] array) {
+        public boolean validate(T[] array) {
             return array != null && Validator.super.validate(array);
         }
 
         @Override
-        public boolean validate(Iterable<Object> iterable){
+        public boolean validate(Iterable<T> iterable) {
             return iterable != null && Validator.super.validate(iterable);
         }
     }

--- a/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/Nullable.java
+++ b/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/Nullable.java
@@ -16,12 +16,12 @@ public @interface Nullable {
 
     class ValidatorImpl implements Validator<Object> {
         @Override
-        public boolean validate(Object obj) {
+        public boolean validate(Object object) {
             return true;
         }
 
         @Override
-        public boolean validate(Object[] obj) {
+        public boolean validate(Object[] array) {
             return true;
         }
     }

--- a/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/Nullable.java
+++ b/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/Nullable.java
@@ -24,6 +24,11 @@ public @interface Nullable {
         public boolean validate(Object[] array) {
             return true;
         }
+
+        @Override
+        public boolean validate(Iterable<Object> iterable) {
+            return true;
+        }
     }
 
 }

--- a/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/OfLength.java
+++ b/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/OfLength.java
@@ -27,8 +27,8 @@ public @interface OfLength {
         }
 
         @Override
-        public boolean validate(String obj) {
-            return obj == null || obj.length() == ofLength;
+        public boolean validate(String object) {
+            return object == null || object.length() == ofLength;
         }
 
     }

--- a/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/Validator.java
+++ b/fluapigen-validation-api/src/main/java/io/toolisticon/fluapigen/validation/api/Validator.java
@@ -1,5 +1,8 @@
 package io.toolisticon.fluapigen.validation.api;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 /**
  * The Validator interface.
  *
@@ -12,19 +15,23 @@ public interface Validator<TYPE> {
     /**
      * Validates passed in instance.
      *
-     * @param obj the object to validate
-     * @return true if obj is valid otherwise false
+     * @param object the object to validate
+     * @return true if object is valid otherwise false
      */
-    boolean validate(TYPE obj);
-
-    default boolean validate(TYPE[] obj) {
-        if (obj != null) {
-            for (TYPE element : obj) {
+    boolean validate(TYPE object);
+    default boolean validate(TYPE[] array){
+        if(array!=null){
+            return validate(Arrays.asList(array));
+        }
+        return true;
+    }
+    default boolean validate(Iterable<TYPE> iterable) {
+        if (iterable != null) {
+            for (TYPE element : iterable) {
                 if (!validate(element)) {
                     return false;
                 }
             }
-
         }
         return true;
     }

--- a/fluapigen-validation-api/src/test/java/io/toolisticon/fluapigen/validation/api/HasNoArgConstructorTest.java
+++ b/fluapigen-validation-api/src/test/java/io/toolisticon/fluapigen/validation/api/HasNoArgConstructorTest.java
@@ -4,6 +4,7 @@ import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 
 import java.lang.reflect.Modifier;
+import java.util.Arrays;
 
 /**
  * Unit test for {@link MaxLength}.
@@ -49,6 +50,46 @@ public class HasNoArgConstructorTest {
         int[] expectedModifiers = {Modifier.PUBLIC};
         HasNoArgConstructor.ValidatorImpl unitWithModifiers = new HasNoArgConstructor.ValidatorImpl(expectedModifiers);
         MatcherAssert.assertThat("Expect to match", unitWithModifiers.validate(TestHasDefaultNoarg.class));
+
+
+    }
+
+    @Test
+    public void doValidationTest_iterableValue() {
+
+        int[] modifiers = {};
+
+        HasNoArgConstructor.ValidatorImpl unit = new HasNoArgConstructor.ValidatorImpl(modifiers);
+
+        Iterable<Class<?>> classes = Arrays.asList(TestHasDefaultNoarg.class, TestHasExplicitNoarg.class);
+        Iterable<Class<?>> nonMatchingClasses = Arrays.asList(TestHasDefaultNoarg.class, TestHasExplicitNoarg.class,TestHasNoNoarg.class);
+        Iterable<Class<?>> nullValuedClasses = null;
+        Iterable<Class<?>> nullValuedElementClasses = Arrays.asList(TestHasDefaultNoarg.class, TestHasExplicitNoarg.class,null);
+
+        MatcherAssert.assertThat("Expect to match", unit.validate(classes));
+        MatcherAssert.assertThat("Expect not to match", !unit.validate(nonMatchingClasses));
+        MatcherAssert.assertThat("Expect to return true in case of null ", unit.validate(nullValuedClasses));
+        MatcherAssert.assertThat("Expect to return true in case of null ", unit.validate(nullValuedElementClasses));
+
+
+    }
+
+    @Test
+    public void doValidationTest_arrayValue() {
+
+        int[] modifiers = {};
+
+        HasNoArgConstructor.ValidatorImpl unit = new HasNoArgConstructor.ValidatorImpl(modifiers);
+
+        Class<?>[] classes = {TestHasDefaultNoarg.class, TestHasExplicitNoarg.class};
+        Class<?>[] nonMatchingClasses = {TestHasDefaultNoarg.class, TestHasExplicitNoarg.class,TestHasNoNoarg.class};
+        Class<?>[] nullValuedClasses = null;
+        Class<?>[] nullValuedElementClasses = {TestHasDefaultNoarg.class, TestHasExplicitNoarg.class,null};
+
+        MatcherAssert.assertThat("Expect to match", unit.validate(classes));
+        MatcherAssert.assertThat("Expect not to match", !unit.validate(nonMatchingClasses));
+        MatcherAssert.assertThat("Expect to return true in case of null ", unit.validate(nullValuedClasses));
+        MatcherAssert.assertThat("Expect to return true in case of null ", unit.validate(nullValuedElementClasses));
 
 
     }

--- a/fluapigen-validation-api/src/test/java/io/toolisticon/fluapigen/validation/api/MatchesTest.java
+++ b/fluapigen-validation-api/src/test/java/io/toolisticon/fluapigen/validation/api/MatchesTest.java
@@ -3,6 +3,8 @@ package io.toolisticon.fluapigen.validation.api;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 /**
  * Unit test for {@link Matches}.
  */
@@ -20,7 +22,7 @@ public class MatchesTest {
     }
 
     @Test
-    public void doValidationTest_multipleValues () {
+    public void doValidationTest_multipleValuesInArray () {
 
         Matches.ValidatorImpl unit = new Matches.ValidatorImpl(".*[@].*");
 
@@ -33,6 +35,24 @@ public class MatchesTest {
         MatcherAssert.assertThat("Expect not to match", !unit.validate(nonMatchingArray));
         MatcherAssert.assertThat("Expect to return true in case of null value", unit.validate((String[])null));
         MatcherAssert.assertThat("Expect to return true in case of null valued element", unit.validate(matchingArrayWithNullValue));
+
+
+    }
+
+    @Test
+    public void doValidationTest_multipleValuesInIterable () {
+
+        Matches.ValidatorImpl unit = new Matches.ValidatorImpl(".*[@].*");
+
+        final Iterable<String> matchingIterable = Arrays.asList("tobias.stamann@holisticon.de", "tobias.stamann@holisticon.de");
+        final Iterable<String> nonMatchingIterable = Arrays.asList("tobias.stamann@holisticon.de", "someNotMatchingText");
+        final Iterable<String> matchingIterableWithNullValue = Arrays.asList("tobias.stamann@holisticon.de", null);
+
+
+        MatcherAssert.assertThat("Expect to match", unit.validate(matchingIterable));
+        MatcherAssert.assertThat("Expect not to match", !unit.validate(nonMatchingIterable));
+        MatcherAssert.assertThat("Expect to return true in case of null value", unit.validate((Iterable<String>) null));
+        MatcherAssert.assertThat("Expect to return true in case of null valued element", unit.validate(matchingIterableWithNullValue));
 
 
     }

--- a/fluapigen-validation-api/src/test/java/io/toolisticon/fluapigen/validation/api/MaxLengthTest.java
+++ b/fluapigen-validation-api/src/test/java/io/toolisticon/fluapigen/validation/api/MaxLengthTest.java
@@ -24,7 +24,7 @@ public class MaxLengthTest {
     }
 
     @Test
-    public void doValidationTest_multipleValues () {
+    public void doValidationTest_multipleValuesInArray () {
 
         MaxLength.ValidatorImpl unit = new MaxLength.ValidatorImpl(5);
 
@@ -36,6 +36,24 @@ public class MaxLengthTest {
         MatcherAssert.assertThat("Expect not to match", !unit.validate(nonMatchingArray));
         MatcherAssert.assertThat("Expect to return true in case of null value", unit.validate((String[])null));
         MatcherAssert.assertThat("Expect to return true in case of null element value", unit.validate(matchingArrayWithNullValue));
+
+
+    }
+
+
+    @Test
+    public void doValidationTest_multipleValuesInIterable () {
+
+        MaxLength.ValidatorImpl unit = new MaxLength.ValidatorImpl(5);
+
+        final Iterable<String> matchingIterable = Arrays.asList("", "abc","abcde");
+        final Iterable<String> nonMatchingIterable = Arrays.asList("", "abc", "adsada","abcde");
+        final Iterable<String> matchingIterableWithNullValue = Arrays.asList("abc", null);
+
+        MatcherAssert.assertThat("Expect to match", unit.validate(matchingIterable));
+        MatcherAssert.assertThat("Expect not to match", !unit.validate(nonMatchingIterable));
+        MatcherAssert.assertThat("Expect to return true in case of null value", unit.validate((Iterable<String>)null));
+        MatcherAssert.assertThat("Expect to return true in case of null element value", unit.validate(matchingIterableWithNullValue));
 
 
     }

--- a/fluapigen-validation-api/src/test/java/io/toolisticon/fluapigen/validation/api/MinLengthTest.java
+++ b/fluapigen-validation-api/src/test/java/io/toolisticon/fluapigen/validation/api/MinLengthTest.java
@@ -3,6 +3,8 @@ package io.toolisticon.fluapigen.validation.api;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 /**
  * Unit test for {@link MinLength}.
  */
@@ -22,7 +24,7 @@ public class MinLengthTest {
     }
 
     @Test
-    public void doValidationTest_multipleValues() {
+    public void doValidationTest_multipleValuesInArray() {
 
         MinLength.ValidatorImpl unit = new MinLength.ValidatorImpl(5);
 
@@ -34,6 +36,23 @@ public class MinLengthTest {
         MatcherAssert.assertThat("Expect not to match", !unit.validate(nonMatchingArray));
         MatcherAssert.assertThat("Expect to return true in case of null value", unit.validate((String[]) null));
         MatcherAssert.assertThat("Expect to return true in case of null element value", unit.validate(matchingArrayWithNullValue));
+
+
+    }
+
+    @Test
+    public void doValidationTest_multipleValuesInIterable() {
+
+        MinLength.ValidatorImpl unit = new MinLength.ValidatorImpl(5);
+
+        final Iterable<String> nonMatchingIterable = Arrays.asList("", "abc", "abcde");
+        final Iterable<String> matchingIterable = Arrays.asList("adsada", "gdgugjvhkbhkjbh");
+        final Iterable<String> matchingIterableWithNullValue = Arrays.asList("abcde", null);
+
+        MatcherAssert.assertThat("Expect to match", unit.validate(matchingIterable));
+        MatcherAssert.assertThat("Expect not to match", !unit.validate(nonMatchingIterable));
+        MatcherAssert.assertThat("Expect to return true in case of null value", unit.validate((Iterable<String>) null));
+        MatcherAssert.assertThat("Expect to return true in case of null element value", unit.validate(matchingIterableWithNullValue));
 
 
     }

--- a/fluapigen-validation-api/src/test/java/io/toolisticon/fluapigen/validation/api/NotEmptyTest.java
+++ b/fluapigen-validation-api/src/test/java/io/toolisticon/fluapigen/validation/api/NotEmptyTest.java
@@ -3,6 +3,8 @@ package io.toolisticon.fluapigen.validation.api;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 /**
  * Unit test for {@link MinLength}.
  */
@@ -21,7 +23,7 @@ public class NotEmptyTest {
     }
 
     @Test
-    public void doValidationTest_multipleValues() {
+    public void doValidationTest_multipleValuesInArray() {
 
         NotEmpty.ValidatorImpl unit = new NotEmpty.ValidatorImpl();
 
@@ -33,6 +35,23 @@ public class NotEmptyTest {
         MatcherAssert.assertThat("Expect not to match", !unit.validate(nonMatchingArray));
         MatcherAssert.assertThat("Expect to return true in case of null value", unit.validate((String[]) null));
         MatcherAssert.assertThat("Expect to return true in case of null element value", unit.validate(matchingArrayWithNullValue));
+
+
+    }
+
+    @Test
+    public void doValidationTest_multipleValuesInIterable() {
+
+        NotEmpty.ValidatorImpl unit = new NotEmpty.ValidatorImpl();
+
+        final Iterable<String> nonMatchingIterable = Arrays.asList("", "abc", "abcde");
+        final Iterable<String> matchingIterable = Arrays.asList("adsada", "gdgugjvhkbhkjbh");
+        final Iterable<String> matchingIterableWithNullValue = Arrays.asList("abcde", null);
+
+        MatcherAssert.assertThat("Expect to match", unit.validate(matchingIterable));
+        MatcherAssert.assertThat("Expect not to match", !unit.validate(nonMatchingIterable));
+        MatcherAssert.assertThat("Expect to return true in case of null value", unit.validate((Iterable<String>) null));
+        MatcherAssert.assertThat("Expect to return true in case of null element value", unit.validate(matchingIterableWithNullValue));
 
 
     }

--- a/fluapigen-validation-api/src/test/java/io/toolisticon/fluapigen/validation/api/NotNullTest.java
+++ b/fluapigen-validation-api/src/test/java/io/toolisticon/fluapigen/validation/api/NotNullTest.java
@@ -3,6 +3,8 @@ package io.toolisticon.fluapigen.validation.api;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 /**
  * Unit test for {@link NotNull}.
  */
@@ -19,7 +21,7 @@ public class NotNullTest {
     }
 
     @Test
-    public void doValidationTest_multipleValues() {
+    public void doValidationTest_multipleValuesInArray() {
 
         NotNull.ValidatorImpl unit = new NotNull.ValidatorImpl();
 
@@ -30,6 +32,22 @@ public class NotNullTest {
         MatcherAssert.assertThat("Expect to match", unit.validate(matchingArray));
         MatcherAssert.assertThat("Expect not to match", !unit.validate(nonMatchingArray));
         MatcherAssert.assertThat("Expect to return false in case of null value", !unit.validate((String[]) null));
+
+
+    }
+
+    @Test
+    public void doValidationTest_multipleValuesinIterable() {
+
+        NotNull.ValidatorImpl unit = new NotNull.ValidatorImpl();
+
+        final Iterable<String> matchingIterable = Arrays.asList("tobias.stamann@holisticon.de", "tobias.stamann@holisticon.de");
+        final Iterable<String> nonMatchingIterable = Arrays.asList("tobias.stamann@holisticon.de", null);
+
+
+        MatcherAssert.assertThat("Expect to match", unit.validate(matchingIterable));
+        MatcherAssert.assertThat("Expect not to match", !unit.validate(nonMatchingIterable));
+        MatcherAssert.assertThat("Expect to return false in case of null value", !unit.validate((Iterable<String>) null));
 
 
     }

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <!-- project dependency versions -->
         <cute.version>1.0.1</cute.version>
         <spiap.version>0.11.0</spiap.version>
-        <aptk.version>0.22.12-SNAPSHOT</aptk.version>
+        <aptk.version>0.23.0</aptk.version>
 
         <!-- versions of test dependencies -->
         <junit.version>4.13.2</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <!-- project dependency versions -->
         <cute.version>1.0.1</cute.version>
         <spiap.version>0.11.0</spiap.version>
-        <aptk.version>0.22.11</aptk.version>
+        <aptk.version>0.22.12-SNAPSHOT</aptk.version>
 
         <!-- versions of test dependencies -->
         <junit.version>4.13.2</junit.version>


### PR DESCRIPTION
Sometimes it is handy to give values as an Iterable to the backing bean. Also, the validation of the Iterable as notNull and its elements should be added.